### PR TITLE
alt text for archive pages

### DIFF
--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 	{% block content %}
 		{% if post.thumbnail.src %}
 			<div class="iastate22-card__media">
-				<img src="{{post.thumbnail.src}}" />
+				<img src="{{post.thumbnail.src}}" alt="{{post.thumbNail.alt}}" />
 			</div>
 		{% endif %}
 		<div class="iastate22-card__content">


### PR DESCRIPTION
This adds the media library's alt text to archive page thumbnails in the post loop. Will be blank if none is present.