### PR TITLE
Add event date to event listings in dashboard

### DIFF
--- a/inc/post-types/events.php
+++ b/inc/post-types/events.php
@@ -119,3 +119,22 @@ function acf_custom_event_changed_check( $value, $post_id, $field, $original ) {
 }
 
 add_action( 'acf/update_value/key=field_64c2a145cab1f', 'acf_custom_event_changed_check', 10, 4 );
+
+function add_event_start_date_to_listings() {
+        add_filter( 'manage_events_posts_columns', 'add_start_date_column' );
+        add_action( 'manage_pages_custom_column', 'add_start_date_value', 10, 2 );
+    }
+
+add_action( 'init', 'add_event_start_date_to_listings' );
+
+function add_start_date_column( $columns ) {
+    $columns['event_start_date'] = 'Event Start Date';
+    return $columns;
+}
+
+function add_start_date_value( $column_name, $post_id ) {
+    if ( $column_name == 'event_start_date' ) {
+       $the_start_date = get_post_meta($post_id, 'event_start_date_start_date');
+       echo date("m/d/Y",strtotime($the_start_date[0]));
+    }
+}

--- a/inc/post-types/events.php
+++ b/inc/post-types/events.php
@@ -6,7 +6,7 @@ function custom_event() {
 	if ( true !== get_field( 'events_options_enabled', 'options' ) ) {
 		return;
 	}
-	
+
 	$events_labels = array(
 		'name'                  => _x( 'Events', 'Events General Name' ),
 		'singular_name'         => _x( 'Event', 'Event Singular Name' ),
@@ -69,7 +69,7 @@ function custom_event() {
 		'new_item_name'     => __( 'New Tag Name' ),
 		'menu_name'         => __( 'Tags' ),
 	);
-	
+
 	register_taxonomy( 'event_tags', 'events', array(
 		// Hierarchical taxonomy (like categories)
 		'hierarchical' => true,
@@ -82,12 +82,12 @@ function custom_event() {
 			'with_front'   => false, // Don't display the category base before "/locations/"
 			'hierarchical' => true // This will allow URL's like "/locations/boston/cambridge/"
 		),
-		) 
+		)
 	);
 
 	add_action( 'wp_enqueue_scripts', 'acf_custom_events_api_path_override', 11);
 }
-	
+
 add_action( 'init', 'custom_event', 0 );
 
 function acf_custom_events_api_path_override(){
@@ -102,7 +102,7 @@ function acf_custom_event_changed_check( $value, $post_id, $field, $original ) {
 	}
 	$current_value    = intval( get_field( 'events_options_enabled', 'options' ) );
 	$normalized_value = intval( $value );
-	
+
 	if ( $current_value !== $normalized_value ) {
 		// option changed, flush needed.
 		add_action( 'acf/options_page/save', function () {
@@ -120,21 +120,42 @@ function acf_custom_event_changed_check( $value, $post_id, $field, $original ) {
 
 add_action( 'acf/update_value/key=field_64c2a145cab1f', 'acf_custom_event_changed_check', 10, 4 );
 
-function add_event_start_date_to_listings() {
-        add_filter( 'manage_events_posts_columns', 'add_start_date_column' );
-        add_action( 'manage_pages_custom_column', 'add_start_date_value', 10, 2 );
-    }
+function admin_event_table_listings() {
+	add_filter( 'manage_events_posts_columns', 'add_event_table_columns' );
+	add_action( 'manage_pages_custom_column', 'add_event_table_column_data', 10, 2 );
+}
+add_action( 'admin_init', 'admin_event_table_listings' );
 
-add_action( 'init', 'add_event_start_date_to_listings' );
-
-function add_start_date_column( $columns ) {
-    $columns['event_start_date'] = 'Event Start Date';
-    return $columns;
+function add_event_table_columns( $columns ) {
+	return array_merge(
+		array_slice( $columns, 0, 2 ),
+		array(
+			'event_start_date' => esc_html__( 'Event Start' ),
+			'event_end_date'   => esc_html__( 'Event End' ),
+		),
+		array_slice( $columns, 2 )
+	);
 }
 
-function add_start_date_value( $column_name, $post_id ) {
-    if ( $column_name == 'event_start_date' ) {
-       $the_start_date = get_post_meta($post_id, 'event_start_date_start_date');
-       echo date("m/d/Y",strtotime($the_start_date[0]));
-    }
+function add_event_table_column_data( $column_name, $post_id ) {
+	if ( in_array( $column_name, array( 'event_start_date', 'event_end_date' ), true ) ) {
+		$full_day = 1;
+		$date     = null;
+		$time     = null;
+		if ( 'event_start_date' === $column_name ) {
+			$full_day = get_post_meta( $post_id, 'event_start_date_full_day', true );
+			$date     = get_post_meta( $post_id, 'event_start_date_start_date', true );
+			$time     = get_post_meta( $post_id, 'event_start_date_start_time', true );
+		}
+		if ( 'event_end_date' === $column_name ) {
+			$full_day = get_post_meta( $post_id, 'event_end_date_full_day', true );
+			$date     = get_post_meta( $post_id, 'event_end_date_end_date', true );
+			$time     = get_post_meta( $post_id, 'event_end_date_end_time', true );
+		}
+		$format    = $full_day ? get_option( 'date_format' ) : get_option( 'date_format' ) . ' ' . get_option( 'time_format' );
+		$timestamp = $full_day ? $date : $date . ' ' . $time;
+
+		echo esc_html( gmdate( $format, strtotime( $timestamp ) ) );
+	}
+
 }

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 	{% block content %}
 		{% if post.thumbnail.src %}
 			<div class="iastate22-card__media">
-				<img src="{{post.thumbnail.src}}" />
+				<img src="{{post.thumbnail.src}}" alt="{{post.thumbNail.alt}}" />
 			</div>
 		{% endif %}
 		<div class="iastate22-card__content">

--- a/templates/tease-post.twig
+++ b/templates/tease-post.twig
@@ -2,7 +2,7 @@
 	{% block content %}
 		{% if post.thumbnail.src %}
 			<div class="iastate22-card__media">
-				<img src="{{post.thumbnail.src}}" alt="{{post.thumbNail.alt}}" />
+				<img src="{{post.thumbnail.src}}" alt="{{post.thumbnail.alt}}" />
 			</div>
 		{% endif %}
 		<div class="iastate22-card__content">


### PR DESCRIPTION
This adds a column to the Event listings in the Wordpress backend so you can see the start date of the event, making it easier to find a specific event when browsing to edit/review.