### PR TITLE
Profiles feature search fixes

### DIFF
--- a/archive-profiles.php
+++ b/archive-profiles.php
@@ -51,12 +51,26 @@ if(strlen($search_letter) > 0) {
 
 $arr = array(
     'post_type' => 'profiles',
-    'order' => 'DESC',
-    'orderby' => 'meta_value',
+    'order' => 'ASC',
+    'orderby' => array(
+        'last_name_clause' => 'ASC',
+        'first_name_clause' => 'ASC',
+    ),
+    'meta_key' => 'last_name',
     'paged' => $paged,
     's' => $s,
     'tax_query' => $tax_query,
-    'meta_query' => $meta_query
+    'meta_query' => array (
+        'relation' => 'AND',
+        'last_name_clause' => array(
+            'key' => 'last_name',
+            'compare' => 'EXISTS'
+        ),
+         'first_name_clause' => array(
+            'key' => 'first_name',
+            'compare' => 'EXISTS'
+        ),$meta_query
+       )
 );
 $argh = array(
     'post_type' => 'profiles',

--- a/search.php
+++ b/search.php
@@ -49,15 +49,29 @@ if(get_query_var("post_type") == "profiles") {
         );
     }
 
-    $arr = array(
-        'post_type' => 'profiles',
-        'order' => 'DESC',
-        'orderby' => 'meta_value',
-        'paged' => $paged,
-        's' => $s,
-        'tax_query' => $tax_query,
-        'meta_query' => $meta_query
-    );
+  $arr = array(
+    'post_type' => 'profiles',
+    'order' => 'ASC',
+    'orderby' => array(
+        'last_name_clause' => 'ASC',
+        'first_name_clause' => 'ASC',
+    ),
+    'meta_key' => 'last_name',
+    'paged' => $paged,
+    's' => $s,
+    'tax_query' => $tax_query,
+    'meta_query' => array (
+        'relation' => 'AND',
+        'last_name_clause' => array(
+            'key' => 'last_name',
+            'compare' => 'EXISTS'
+        ),
+         'first_name_clause' => array(
+            'key' => 'first_name',
+            'compare' => 'EXISTS'
+        ),$meta_query
+       )
+);
     $argh = array(
         'post_type' => 'profiles',
         'posts_per_page' => -1,


### PR DESCRIPTION
Fixes the following:

On first loading /profiles/ -  profiles will be sorted by last name then first name. Previously it was sorting in post date order, ascending which was awkward.

The same fix was applied to the profile search results. 