### PR TITLE
Do not display h1 if empty wp_title or hero_title

### DIFF
--- a/templates/blocks/news-hero.twig
+++ b/templates/blocks/news-hero.twig
@@ -1,13 +1,15 @@
 <div class="hero"{% if block.anchor|length > 0 %} id="{{ block.anchor|e('esc_attr') }}"{% endif %}>
 	<div class="hero__text-wrap">
 		{% include ['templates/partial/breadcrumbs.twig'] %}
-		<h1 class="hero__title">
-			{% if post.meta('hero_title') %}
-				{{ post.meta('hero_title') }}
-			{% else %}
-				{{ wp_title }}
-			{% endif %}
-		</h1>
+		{% if field.hero_title or wp_title %}
+			<h1 class="hero__title">
+				{% if fields.hero_title %}
+					{{ fields.hero_title }}
+				{% else %}
+					{{ wp_title }}
+				{% endif %}
+			</h1>
+		{% endif %}
 	</div>
 	{% if post.meta('hero_image') %}
 		<div class="hero__media">


### PR DESCRIPTION
Resolves https://github.com/iastate/iastate22-wordpress/issues/45

Empty h1s are a result of an empty wp_title call if a site set to "your homepage displays latest posts"

Checking to see if either wp_title or field.hero_title exists will fix the empty h1 in such cases.