### PR TITLE
Fixed name of alt text field on personal profiles

### DIFF
--- a/templates/partial/personal-profile-info-card.twig
+++ b/templates/partial/personal-profile-info-card.twig
@@ -1,7 +1,7 @@
 <div class="personal-profile-info-card{% if not photo %} personal-profile-info-card--no-image{% endif %}">
 	{% if photo %}
 		<div class="personal-profile-info-card__media">
-			<img src="{{ photo.url|e('esc_url') }}" alt="{{ photo.description|e('esc_attr') }}">
+			<img src="{{ photo.url|e('esc_url') }}" alt="{{ photo.alt|e('esc_attr') }}"> 
 		</div>
 	{% endif %}
 


### PR DESCRIPTION
The field name for the alt text on the personal profile info card was incorrect. Corrected the name and alt text appears as expected.

https://github.com/iastate/iastate22-wordpress/issues/41