### PR TITLE
Add posted date before author per fractal

### DIFF
--- a/templates/single.twig
+++ b/templates/single.twig
@@ -20,6 +20,7 @@
 			{% if post.meta('subhead') %}
 				<h2 class="hero--news-article__subhead">{{ post.meta('subhead') }}</h2>
 			{% endif %}
+			<div class="hero--news-article__date">{{ post.date }}</div>
 			{% if show_author %}
 				<div class="hero--news-article__attribution"><p><strong>Author: {{ post.author.name }}</strong></p>
 				</div>


### PR DESCRIPTION
Added posted date to template in the correct spot. Displays as:

October 2, 2024

post.date

Part of me wants to add a display toggle, but not sure it is needed.