### PR TITLE
Change date shown on pages in search results to last modified

### DIFF
--- a/templates/loops/loop-posts.twig
+++ b/templates/loops/loop-posts.twig
@@ -35,7 +35,11 @@
 								<a class="iastate22-link-secondary"
 								   href="{{ post.link|e('esc_url') }}">{{ post.post_title }}<span class="arrow"></span></a>
 							</h2>
-							<p class="hero-stories-feed-item__content-date">{{ post.date }}</p>
+							{% if post.type == 'page' %}
+								<p class="hero-stories-feed-item__content-date">{{ post.modified_date }}</p>
+								{% else %}
+									<p class="hero-stories-feed-item__content-date">{{ post.date }}</p>
+							{% endif %}
 						</div>
 					</div>
 				{% endfor %}

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -20,6 +20,7 @@
 			{% if post.meta('subhead') %}
 				<h2 class="hero--news-article__subhead">{{ post.meta('subhead') }}</h2>
 			{% endif %}
+			<div class="hero--news-article__date">{{ post.date }}</div>
 			{% if show_author %}
 				<div class="hero--news-article__attribution"><p><strong>Author: {{ post.author.name }}</strong></p>
 				</div>

--- a/templates/single.twig
+++ b/templates/single.twig
@@ -20,7 +20,6 @@
 			{% if post.meta('subhead') %}
 				<h2 class="hero--news-article__subhead">{{ post.meta('subhead') }}</h2>
 			{% endif %}
-			<div class="hero--news-article__date">{{ post.date }}</div>
 			{% if show_author %}
 				<div class="hero--news-article__attribution"><p><strong>Author: {{ post.author.name }}</strong></p>
 				</div>


### PR DESCRIPTION
Pages can have old creation dates, but showing an old date in search results looks bad and is inaccurate. This changes the search loop to display the last modified date for a page in search results, but retains a post's originally created date.